### PR TITLE
fix: icon configured for android

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
     "android": {
       "package": "com.myorg.barugapp",
       "adaptiveIcon": {
-        "foregroundImage": "./assets/images/adaptive-icon.png",
+        "foregroundImage": "./assets/images/brgy_sto_nino_logo.png",
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true


### PR DESCRIPTION
This pull request makes a minor update to the Android app configuration by changing the adaptive icon's foreground image to use the `brgy_sto_nino_logo.png` asset.